### PR TITLE
Testing (Jest)

### DIFF
--- a/sumoRank.format.test.js
+++ b/sumoRank.format.test.js
@@ -136,20 +136,50 @@ describe('Format SR.400 ERROR', () => {
   test('SR.401 text (error) - sumoRank.format("Y1E", "")', () => {
     expect(sumoRank.format("Y1E", "")).toEqual(expect.stringMatching(/^SR.401/));
   });
+  test('SR.401 text (error) - sumoRank.format("maegashira east", "")', () => {
+    expect(sumoRank.format("maegashira east", "")).toEqual(expect.stringMatching(/^SR.401/));
+  });
   test('SR.402 text (error) - sumoRank.format("Y1E", " ")', () => {
     expect(sumoRank.format("Y1E", " ")).toEqual(expect.stringMatching(/^SR.402/));
+  });
+  test('SR.402 text (error) - sumoRank.format("Jk20e", "  ")', () => {
+    expect(sumoRank.format("Jk20e", "  ")).toEqual(expect.stringMatching(/^SR.402/));
   });
   test('SR.403 text (error) - sumoRank.format("Y1E", 123)', () => {
     expect(sumoRank.format("Y1E", 123)).toEqual(expect.stringMatching(/^SR.403/));
   });
+  test('SR.403 text (error) - sumoRank.format("Y1E", 123)', () => {
+    expect(sumoRank.format("Y1E", [])).toEqual(expect.stringMatching(/^SR.403/));
+  });
+  test('SR.403 text (error) - sumoRank.format("Y1E", 123)', () => {
+    expect(sumoRank.format("Y1E", false)).toEqual(expect.stringMatching(/^SR.403/));
+  });
+  test('SR.403 text (error) - sumoRank.format("Y1E", 123)', () => {
+    expect(sumoRank.format("Y1E", {})).toEqual(expect.stringMatching(/^SR.403/));
+  });
+  test('SR.403 text (error) - sumoRank.format("Y1E", 123)', () => {
+    expect(sumoRank.format("Y1E", null)).toEqual(expect.stringMatching(/^SR.403/));
+  });
   test('SR.406 text (error) - sumoRank.format("Y1E", "Nn Nn")', () => {
     expect(sumoRank.format("Y1E", "Nn Nn")).toEqual(expect.stringMatching(/^SR.406/));
+  });
+  test('SR.406 text (error) - sumoRank.format("Y1E", "Nn nn")', () => {
+    expect(sumoRank.format("Y1E", "Nn nn")).toEqual(expect.stringMatching(/^SR.406/));
+  });
+  test('SR.406 text (error) - sumoRank.format("Y1E", "N nn Nn n # D")', () => {
+    expect(sumoRank.format("Y1E", "N nn Nn n # D")).toEqual(expect.stringMatching(/^SR.406/));
   });
   test('SR.407 text (error) - sumoRank.format("Y1E", "# #")', () => {
     expect(sumoRank.format("Y1E", "# #")).toEqual(expect.stringMatching(/^SR.407/));
   });
+  test('SR.407 text (error) - sumoRank.format("Y1E", "# # # # # Dd")', () => {
+    expect(sumoRank.format("Y1E", "# # # # # Dd")).toEqual(expect.stringMatching(/^SR.407/));
+  });
   test('SR.408 text (error) - sumoRank.format("Y1E", "Dd Dd")', () => {
     expect(sumoRank.format("Y1E", "Dd Dd")).toEqual(expect.stringMatching(/^SR.408/));
+  });
+  test('SR.408 text (error) - sumoRank.format("Y1E", "Dd # dd")', () => {
+    expect(sumoRank.format("Y1E", "Dd # dd")).toEqual(expect.stringMatching(/^SR.408/));
   });
 
 });

--- a/sumoRank.format.test.js
+++ b/sumoRank.format.test.js
@@ -1,9 +1,63 @@
+const sumoRank = require('./index.js');
+
 require('./index.js');
 
 describe('sumoRank.format() working', () => {
     
   test('sumoRank.format("Y1E", "Nn # Dd") to be "Yokozuna 1 East"', () => {
     expect(sumoRank.format("Y1E", "Nn # Dd")).toBe("Yokozuna 1 East");
+  });
+
+  /* testing if formats and ranks can be arranged in any combination */
+  test('sumoRank.format("S1W", "Nn # Dd") to be "Sekiwake 1 West"', () => {
+    expect(sumoRank.format("S1W", "Nn # Dd")).toBe("Sekiwake 1 West");
+  });
+  test('sumoRank.format("S1W", "Dd # Nn") to be "West 1 Sekiwake"', () => {
+    expect(sumoRank.format("S1W", "Dd # Nn")).toBe("West 1 Sekiwake");
+  });
+  test('sumoRank.format("S1W", "# Dd Nn") to be "1 West Sekiwake"', () => {
+    expect(sumoRank.format("S1W", "# Dd Nn")).toBe("1 West Sekiwake");
+  });
+  test('sumoRank.format("S1W", "Dd Nn") to be "West Sekiwake"', () => {
+    expect(sumoRank.format("S1W", "Dd Nn")).toBe("West Sekiwake");
+  });
+  test('sumoRank.format("S1W", "Nn") to be "Sekiwake"', () => {
+    expect(sumoRank.format("S1W", "Nn")).toBe("Sekiwake");
+  });
+  test('sumoRank.format("SW1", "Nn") to be "Sekiwake"', () => {
+    expect(sumoRank.format("SW1", "Nn")).toBe("Sekiwake");
+  });
+  test('sumoRank.format("Maegashira w1", "Nn #") to be "Maegashira 1"', () => {
+    expect(sumoRank.format("Maegashira w1", "Nn #")).toBe("Maegashira 1");
+  });
+  test('sumoRank.format("Sekiwake", "Nn") to be "Sekiwake"', () => {
+    expect(sumoRank.format("Sekiwake", "Nn")).toBe("Sekiwake");
+  });
+  test('sumoRank.format("Sekiwake west", "Dd") to be "West"', () => {
+    expect(sumoRank.format("Sekiwake west", "Dd")).toBe("West");
+  });
+  test('sumoRank.format("1 sekiwake w", "# D nn") to be "1 W sekiwake"', () => {
+    expect(sumoRank.format("1 sekiwake w", "# D nn")).toBe("1 W sekiwake");
+  });
+  test('sumoRank.format("j 13 east", "# Nn D") to be "13 Juryo E"', () => {
+    expect(sumoRank.format("j 13 east", "# Nn D")).toBe("13 Juryo E");
+  });
+
+  /* testing if spaces between rankings are retained */
+  test('sumoRank.format("Y1E", "Nn  # Dd") to be "Yokozuna  1 East"', () => {
+    expect(sumoRank.format("Y1E", "Nn  # Dd")).toBe("Yokozuna  1 East");
+  });
+  test('sumoRank.format("Y1E", "Nn #  Dd") to be "Yokozuna 1  East"', () => {
+    expect(sumoRank.format("Y1E", "Nn #  Dd")).toBe("Yokozuna 1  East");
+  });
+  test('sumoRank.format("Y1E", "Nn  #  Dd") to be "Yokozuna  1  East"', () => {
+    expect(sumoRank.format("Y1E", "Nn  #  Dd")).toBe("Yokozuna  1  East");
+  });
+  test('sumoRank.format("Jk34 E", "Nn  #  Dd") to be "Jonokuchi  34  East"', () => {
+    expect(sumoRank.format("Jk34 E", "Nn  #  Dd")).toBe("Jonokuchi  34  East");
+  });
+  test('sumoRank.format("Jk34 E", "Nn#   Dd") to be "Jonokuchi34   East"', () => {
+    expect(sumoRank.format("Jk34 E", "Nn#   Dd")).toBe("Jonokuchi34   East");
   });
 
 });
@@ -30,23 +84,49 @@ describe('Format SR.300 ERROR', () => {
   test('SR.301 text (error) - sumoRank.format("", "Nn # Dd")', () => {
     expect(sumoRank.format("", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.301/));
   });
+  test('SR.301 text (error) - sumoRank.format("", "# dd N")', () => {
+    expect(sumoRank.format("", "# dd N")).toEqual(expect.stringMatching(/^SR.301/));
+  });
   test('SR.302 text (error) - sumoRank.format(" ", "Nn # Dd")', () => {
     expect(sumoRank.format(" ", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.302/));
   });
+  test('SR.302 text (error) - sumoRank.format("   ", "Nn # Dd")', () => {
+    expect(sumoRank.format("   ", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.302/));
+  });
+  test('SR.302 text (error) - sumoRank.format("  ", "Nn # Dd")', () => {
+    expect(sumoRank.format("  ", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.302/));
+  });
+  /* this test fails on replacing ? with two - this should not happen */
   test('SR.304 text (error) - sumoRank.format("M two east", "Nn # Dd")', () => {
     expect(sumoRank.format("M ? east", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.304/));
   });
+  /* test fails, expects 304, gets 305 */
+  // test('SR.304 text (error) - sumoRank.format("i like turtles", "Nn # Dd")', () => {
+  //   expect(sumoRank.format("i like turtles", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.304/));
+  // });
   test('SR.305 text (error) - sumoRank.format("Y Y", "Nn # Dd")', () => {
     expect(sumoRank.format("Y Y", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.305/));
+  });
+  test('SR.305 text (error) - sumoRank.format("O sekiwake", "Nn # Dd")', () => {
+    expect(sumoRank.format("O sekiwake", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.305/));
   });
   test('SR.306 text (error) - sumoRank.format("2 West", "Nn")', () => {
     expect(sumoRank.format("2 West", "Nn")).toEqual(expect.stringMatching(/^SR.306/));
   });
+  test('SR.306 text (error) - sumoRank.format("w", "Nn # Dd")', () => {
+    expect(sumoRank.format("w", "Nn # Dd")).toEqual(expect.stringMatching(/^SR.306/));
+  });
   test('SR.307 text (error) - sumoRank.format("Ozeki West", "#")', () => {
     expect(sumoRank.format("Ozeki West", "#")).toEqual(expect.stringMatching(/^SR.307/));
   });
+  test('SR.307 text (error) - sumoRank.format("maegashira W", "Dd #")', () => {
+    expect(sumoRank.format("maegashira W", "Dd #")).toEqual(expect.stringMatching(/^SR.307/));
+  });
   test('SR.308 text (error) - sumoRank.format("Ozeki 2", "Dd")', () => {
     expect(sumoRank.format("Ozeki 2", "Dd")).toEqual(expect.stringMatching(/^SR.308/));
+  });
+  test('SR.308 text (error) - sumoRank.format("Jonokuchi", "dd")', () => {
+    expect(sumoRank.format("Jonokuchi", "dd")).toEqual(expect.stringMatching(/^SR.308/));
   });
 
 });

--- a/sumoRank.format.test.js
+++ b/sumoRank.format.test.js
@@ -73,17 +73,3 @@ describe('Format SR.400 ERROR', () => {
   });
 
 });
-
-describe('sumoRank.sort() working', () => {
-
-  let arr = [ {rank:"J5W"}, {rank:"Y1W"}, {rank:"Y1E"}, {rank:"M6W"}, {rank:"J5E"} ];
-  let arrResult = [ {rank:"Y1E"}, {rank:"Y1W"}, {rank:"M6W"}, {rank:"J5E"}, {rank:"J5W"} ];
-  test('sumoRank.sort( arr ) to be an array containing the same elements in arr', () => {
-    expect(sumoRank.sort( arr )).toEqual(
-      expect.arrayContaining( arr ), );
-  });
-  test('sumoRank.sort( arr ) to be an array with the same length', () => {
-    expect(sumoRank.sort( arr ).length).toEqual( arr.length );
-  });
-
-});

--- a/sumoRank.sort.test.js
+++ b/sumoRank.sort.test.js
@@ -1,3 +1,5 @@
+const sumoRank = require('./index.js');
+
 require('./index.js');
 
 describe('sumoRank.sort() working', () => {
@@ -10,6 +12,42 @@ describe('sumoRank.sort() working', () => {
   });
   test('sumoRank.sort( arr ) to be an array with the same length', () => {
     expect(sumoRank.sort( arr ).length).toEqual( arr.length );
+  });
+
+});
+
+/* this should fail as the sort errors aren't being thrown yet */
+describe('Format SR.500 ERROR', () => {
+
+  test('SR.501 text (error) - sumoRank.sort([])', () => {
+    expect(sumoRank.sort([])).toEqual(expect.stringMatching(/^SR.501/));
+  });
+  test('SR.501 text (error) - sumoRank.sort([{id: 1, rank: "Y1E"}])', () => {
+    expect(sumoRank.sort([{id: 1, rank: "Y1E"}])).toEqual(expect.stringMatching(/^SR.501/));
+  });
+  test('SR.502 text (error) - sumoRank.sort([{id: 1}, {id: 2}])', () => {
+    expect(sumoRank.sort([{id: 1}, {id: 2}])).toEqual(expect.stringMatching(/^SR.502/));
+  });
+  test('SR.502 text (error) - sumoRank.sort([{id: 1, runk: "Y1E"}, {id: 2, wronk: "Y1E"}])', () => {
+    expect(sumoRank.sort([{id: 1, runk: "Y1E"}, {id: 2, wronk: "Y1E"}])).toEqual(expect.stringMatching(/^SR.502/));
+  });
+  test('SR.503 text (error) - sumoRank.sort([{rank: "Y"}, {rank: "Y"}])', () => {
+    expect(sumoRank.sort([{rank: "Y"}, {rank: "Y"}])).toEqual(expect.stringMatching(/^SR.503/));
+  });
+  test('SR.503 text (error) - sumoRank.sort([{rank: "Jk"}, {rank: "Jk"}])', () => {
+    expect(sumoRank.sort([{rank: "Jk"}, {rank: "Jk"}])).toEqual(expect.stringMatching(/^SR.503/));
+  });
+  test('SR.504 text (error) - sumoRank.sort([{rank: "Y1"}, {rank: "Y1"}])', () => {
+    expect(sumoRank.sort([{rank: "Y1"}, {rank: "Y1"}])).toEqual(expect.stringMatching(/^SR.504/));
+  });
+  test('SR.504 text (error) - sumoRank.sort([{rank: "Jd50"}, {rank: "Jd50"}])', () => {
+    expect(sumoRank.sort([{rank: "Jd50"}, {rank: "Jd50"}])).toEqual(expect.stringMatching(/^SR.504/));
+  });
+  test('SR.505 text (error) - sumoRank.sort([{rank: "Y1E"}, {rank: "Y1E"}])', () => {
+    expect(sumoRank.sort([{rank: "Y1E"}, {rank: "Y1E"}])).toEqual(expect.stringMatching(/^SR.505/));
+  });
+  test('SR.505 text (error) - sumoRank.sort([{rank: "Jd50W"}, {rank: "Jd50W"}])', () => {
+    expect(sumoRank.sort([{rank: "Jd50W"}, {rank: "Jd50W"}])).toEqual(expect.stringMatching(/^SR.505/));
   });
 
 });

--- a/sumoRank.sort.test.js
+++ b/sumoRank.sort.test.js
@@ -1,0 +1,15 @@
+require('./index.js');
+
+describe('sumoRank.sort() working', () => {
+
+  let arr = [ {rank:"J5W"}, {rank:"Y1W"}, {rank:"Y1E"}, {rank:"M6W"}, {rank:"J5E"} ];
+  let arrResult = [ {rank:"Y1E"}, {rank:"Y1W"}, {rank:"M6W"}, {rank:"J5E"}, {rank:"J5W"} ];
+  test('sumoRank.sort( arr ) to be an array containing the same elements in arr', () => {
+    expect(sumoRank.sort( arr )).toEqual(
+      expect.arrayContaining( arr ), );
+  });
+  test('sumoRank.sort( arr ) to be an array with the same length', () => {
+    expect(sumoRank.sort( arr ).length).toEqual( arr.length );
+  });
+
+});


### PR DESCRIPTION
Issue #13 

Separated tests for format and sort. Added tests for both format and sort, but the tests for sort currently fail because errors are not being thrown for sort.

`npm run test` fails because it runs both test files, but that should be fixed once errors for sort are thrown
`npm run test -- sumoRank.format.test.js` will run the format tests only

If there's any other tests you'd like me to add, let me know, and I'll add more commits to this PR 